### PR TITLE
Allow usage of static source files besides templates for prometheus.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
 branches:
   only:
   - master
+  - feature/config_file_types2 
   - /^v\d/
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ matrix:
 branches:
   only:
   - master
-  - feature/config_file_types2 
   - /^v\d/
 notifications:
   email: false

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,6 +10,20 @@ class prometheus::config(
   $config_type          = $::prometheus::params::config_type,
 ) {
 
+  case $config_type {
+    'template': {
+      $_config_template = $config_template
+      $_config_source = undef
+    }
+    'source': {
+      $_config_source = $config_source
+      $_config_template = undef
+    }
+    default: {
+      fail("Config file type ${config_type} is not supported by this module")
+    }
+  }
+
   if $prometheus::init_style {
 
     case $prometheus::init_style {
@@ -92,16 +106,8 @@ class prometheus::config(
     owner   => $prometheus::user,
     group   => $prometheus::group,
     mode    => $prometheus::config_mode,
-    content => $config_type ? {
-      'template' => template($config_template),
-      'source'   => undef,
-      default    => fail("Config file type ${config_type} is not supported by this module"),
-    },
-    source  => $config_type ? {
-      'source'   => $config_source,
-      'template' => undef,
-      default    => fail("Config file type ${config_type} is not supported by this module"),
-    },
+    content => $_config_type,
+    source  => $_config_type,
   }
 
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,7 +5,9 @@ class prometheus::config(
   $rule_files,
   $scrape_configs,
   $purge = true,
-  $config_template = $::prometheus::params::config_template,
+  $config_source        = $::prometheus::params::config_source,
+  $config_template      = $::prometheus::params::config_template,
+  $config_type          = $::prometheus::params::config_type,
 ) {
 
   if $prometheus::init_style {
@@ -90,7 +92,16 @@ class prometheus::config(
     owner   => $prometheus::user,
     group   => $prometheus::group,
     mode    => $prometheus::config_mode,
-    content => template($config_template),
+    content => $config_type ? {
+      'content' => template($config_template),
+      'source'  => undef,
+      default   => fail("Config file type ${config_type} is not supported by this module"),
+    },
+    source  => $config_type ? {
+      'source'  => $config_source,
+      'content' => undef,
+      default   => fail("Config file type ${config_type} is not supported by this module"),
+    },
   }
 
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -93,14 +93,14 @@ class prometheus::config(
     group   => $prometheus::group,
     mode    => $prometheus::config_mode,
     content => $config_type ? {
-      'content' => template($config_template),
-      'source'  => undef,
-      default   => fail("Config file type ${config_type} is not supported by this module"),
+      'template' => template($config_template),
+      'source'   => undef,
+      default    => fail("Config file type ${config_type} is not supported by this module"),
     },
     source  => $config_type ? {
-      'source'  => $config_source,
-      'content' => undef,
-      default   => fail("Config file type ${config_type} is not supported by this module"),
+      'source'   => $config_source,
+      'template' => undef,
+      default    => fail("Config file type ${config_type} is not supported by this module"),
     },
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -100,14 +100,28 @@ class prometheus::config(
     purge   => $purge,
     recurse => $purge,
   }
-  -> file { 'prometheus.yaml':
-    ensure  => present,
-    path    => "${prometheus::config_dir}/prometheus.yaml",
-    owner   => $prometheus::user,
-    group   => $prometheus::group,
-    mode    => $prometheus::config_mode,
-    content => $_config_type,
-    source  => $_config_type,
+
+  if $_config_source != undef {
+    file { 'prometheus.yaml':
+      ensure  => file,
+      path    => "${prometheus::config_dir}/prometheus.yaml",
+      owner   => $prometheus::user,
+      group   => $prometheus::group,
+      mode    => $prometheus::config_mode,
+      source  => $_config_source,
+      require => File[$prometheus::config_dir],
+    }
   }
 
+  if $_config_template != undef {
+    file { 'prometheus.yaml':
+      ensure  => file,
+      path    => "${prometheus::config_dir}/prometheus.yaml",
+      owner   => $prometheus::user,
+      group   => $prometheus::group,
+      mode    => $prometheus::config_mode,
+      content => template($_config_template),
+      require => File[$prometheus::config_dir],
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,7 +74,7 @@
 #  Configuration template to use (template/prometheus.yaml.erb)
 #
 #  [*config_type*]
-#  Type of config to use, could be template or file. (default template)
+#  Type of config to use, could be template or source. (default template)
 #
 #  [*config_mode*]
 #  Configuration file mode (default 0660)
@@ -134,7 +134,7 @@ class prometheus (
   $config_defaults      = {},
   $config_source        = $::prometheus::params::config_source,
   $config_template      = $::prometheus::params::config_template,
-  $config_type          = $::prometheus::params::config_template_type,
+  $config_type          = $::prometheus::params::config_type,
   $config_mode          = $::prometheus::params::config_mode,
   $service_enable       = true,
   $service_ensure       = 'running',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,8 +67,14 @@
 #  [*config_defaults*]
 #  Startup config defaults
 #
+#  [*config_source*]
+#  Configuration source to use (undef), default is to use config_template instead
+#
 #  [*config_template*]
 #  Configuration template to use (template/prometheus.yaml.erb)
+#
+#  [*config_type*]
+#  Type of config to use, could be template or file. (default template)
 #
 #  [*config_mode*]
 #  Configuration file mode (default 0660)
@@ -126,7 +132,9 @@ class prometheus (
   $extra_options        = '',
   $config_hash          = {},
   $config_defaults      = {},
+  $config_source        = $::prometheus::params::config_source,
   $config_template      = $::prometheus::params::config_template,
+  $config_type          = $::prometheus::params::config_template_type,
   $config_mode          = $::prometheus::params::config_mode,
   $service_enable       = true,
   $service_ensure       = 'running',
@@ -171,7 +179,9 @@ class prometheus (
     scrape_configs  => $scrape_configs,
     purge           => $purge_config_dir,
     notify          => $notify_service,
+    config_source   => $config_source,
     config_template => $config_template,
+    config_type     => $config_type,
   }
   -> class { '::prometheus::alerts':
     location => $config_dir,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,9 @@ class prometheus::params {
   $bin_dir = '/usr/local/bin'
   $config_dir = '/etc/prometheus'
   $config_mode = '0660'
+  $config_source = undef
   $config_template = 'prometheus/prometheus.yaml.erb'
+  $config_type = 'template'
   $download_extension = 'tar.gz'
   $download_url_base = 'https://github.com/prometheus/prometheus/releases'
   $extra_groups = []

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,7 +8,13 @@ describe 'prometheus' do
       end
 
       describe 'Create the config file' do
-        context 'with the defaults, using the tempate' do
+        context 'by default, using the template' do
+          it do
+            should contain_file('prometheus.yaml')
+              .with(content: /---/)
+          end
+        end
+        context 'when param congi_type is template' do
           it do
             should contain_file('prometheus.yaml')
               .with(content: /---/)

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -10,30 +10,29 @@ describe 'prometheus' do
       describe 'Create the config file' do
         context 'by default, using the template' do
           it do
-            should contain_file('prometheus.yaml')
-              .with(content: /---/)
+            is_expected.to contain_file('prometheus.yaml').
+              with(content: %r{---})
           end
         end
         context 'when param congi_type is template' do
+          let(:params) { { 'config_type' => 'template' } }
           it do
-            should contain_file('prometheus.yaml')
-              .with(content: /---/)
+            is_expected.to contain_file('prometheus.yaml').
+              with(content: %r{---})
           end
         end
         context 'when parameter config_type is source and and config_source is supplied' do
           let(:thesource) { File.expand_path(File.dirname(__FILE__) + '/../fixtures/files/prometheus.yaml') }
-          let(:params) { { :config_type => 'source', :config_source => thesource } }
+          let(:params) { { 'config_type' => 'source', 'config_source' => thesource } }
           it do
-            should contain_file('prometheus.yaml')
-              .with(source: thesource)
+            is_expected.to contain_file('prometheus.yaml').
+              with(source: thesource)
           end
         end
         context 'with an invalid config_type' do
-          let(:params) { { :config_type => 'invalid' } }
+          let(:params) { { 'config_type' => 'invalid' } }
           it do
-            expect {
-              catalogue
-            }.to raise_error(Puppet::Error, /is not supported by this module/)
+            expect { catalogue }.to raise_error(Puppet::Error, %r{is not supported by this module})
           end
         end
       end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'prometheus' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      describe "Create the config file" do
+        context "with the defaults, using the tempate" do
+          it do
+            should contain_file("prometheus.yaml")
+              .with(content: /---/)
+          end
+        end
+        context "when parameter config_type is source and and config_source is supplied" do
+          let(:thesource) { File.expand_path(File.dirname(__FILE__) + '/../fixtures/files/prometheus.yaml') }
+          let(:params) {{ :config_type   => 'source', :config_source => thesource }}
+          it do
+            should contain_file("prometheus.yaml")
+              .with(source: thesource)
+          end
+        end
+        context "with an invalid config_type" do
+          let(:params) {{ :config_type   => 'invalid' }}
+          it do
+            expect {
+              catalogue
+            }.to raise_error(Puppet::Error, /is not supported by this module/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -7,23 +7,23 @@ describe 'prometheus' do
         facts
       end
 
-      describe "Create the config file" do
-        context "with the defaults, using the tempate" do
+      describe 'Create the config file' do
+        context 'with the defaults, using the tempate' do
           it do
-            should contain_file("prometheus.yaml")
+            should contain_file('prometheus.yaml')
               .with(content: /---/)
           end
         end
-        context "when parameter config_type is source and and config_source is supplied" do
+        context 'when parameter config_type is source and and config_source is supplied' do
           let(:thesource) { File.expand_path(File.dirname(__FILE__) + '/../fixtures/files/prometheus.yaml') }
-          let(:params) {{ :config_type   => 'source', :config_source => thesource }}
+          let(:params) { { :config_type => 'source', :config_source => thesource } }
           it do
-            should contain_file("prometheus.yaml")
+            should contain_file('prometheus.yaml')
               .with(source: thesource)
           end
         end
-        context "with an invalid config_type" do
-          let(:params) {{ :config_type   => 'invalid' }}
+        context 'with an invalid config_type' do
+          let(:params) { { :config_type => 'invalid' } }
           it do
             expect {
               catalogue

--- a/spec/fixtures/files/prometheus.yaml
+++ b/spec/fixtures/files/prometheus.yaml
@@ -1,0 +1,1 @@
+samplecontent


### PR DESCRIPTION
These changes allow configuring a static file instead of a template for configuration of prometheus. I use this in combination with a concat static file in my profile.

The defaults stay the same, and other peoples configuration should just keep working as is.