### PR TITLE
Fix several errors on puppet 3

### DIFF
--- a/manifests/alertmanager.pp
+++ b/manifests/alertmanager.pp
@@ -153,6 +153,7 @@ class prometheus::alertmanager (
   $route                = $::prometheus::params::alertmanager_route,
   $service_enable       = true,
   $service_ensure       = 'running',
+  $stop_legacy_service  = true,
   $storage_path         = $::prometheus::params::alertmanager_storage_path,
   $templates            = $::prometheus::params::alertmanager_templates,
   $user                 = $::prometheus::params::alertmanager_user,
@@ -197,8 +198,10 @@ class prometheus::alertmanager (
   }
 
   # This is here to stop the previous alertmanager that was installed in version 0.1.14
-  service { 'alert_manager':
-    ensure => 'stopped',
+  if $stop_legacy_service {
+    service { 'alert_manager':
+      ensure => 'stopped',
+    }
   }
 
   if $storage_path {

--- a/manifests/daemon.pp
+++ b/manifests/daemon.pp
@@ -163,5 +163,11 @@ define prometheus::daemon (
       name   => $init_selector,
       enable => $service_enable,
     }
+    if $manage_user == true {
+      User[$user] -> Service[$name]
+    }
+    if $manage_group == true {
+      Group[$group] -> Service[$name]
+    }
   }
 }

--- a/templates/alerts.erb
+++ b/templates/alerts.erb
@@ -1,14 +1,14 @@
-<% @alerts.sort!{ |a,b| b[:name] <=> a[:name] }.each do |alert| -%>
+<% @alerts.sort!{ |a,b| b['name'] <=> a['name'] }.each do |alert| -%>
 ALERT <%= alert['name'] %>
     IF <%= alert['condition'] %>
     FOR <%= alert['timeduration'] %>
     LABELS {
-    <% alert['labels'].sort!{ |a,b| b[:name] <=> a[:name] }.each do |label| -%>
+    <% alert['labels'].sort!{ |a,b| b['name'] <=> a['name'] }.each do |label| -%>
       <%= label['name'] %> = "<%= label['content'] %>",
     <% end -%>
     }
     ANNOTATIONS {
-    <% alert['annotations'].sort! { |a,b| b[:name] <=> a[:name] }.each do |annotation| -%>
+    <% alert['annotations'].sort!{ |a,b| b['name'] <=> a['name'] }.each do |annotation| -%>
       <%= annotation['name'] %> = "<%= annotation['content'] %>",
     <% end -%>
     }


### PR DESCRIPTION
While implementing this module in our environment I stumbled across several error messages that I fixed.

* The erb template defining alerts did not compile for me, I had to change `:name` to `'name'`
* The service `daemon` class tended to try to start before user and group were created, requiring another puppet run until it could successfully start. Add necessary require statements fixed this.
* The alertmanager class tries to stop a non existent legacy service, causing a non fatal but annoying error message. I added a flag to be able to disable this behavior while keeping backwards compatibility by default.