### PR TITLE
Support alerting configuration for prometheus

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,6 +97,12 @@
 #  [*scrape_configs*]
 #  Prometheus scrape configs
 #
+#  [*alert_relabel_config*]
+#  Prometheus alert relabel config under alerting
+#
+#  [*alertmanagers_config*]
+#  Prometheus managers config under alerting
+#
 # Actions:
 #
 # Requires: see Modulefile
@@ -136,8 +142,9 @@ class prometheus (
   $global_config        = $::prometheus::params::global_config,
   $rule_files           = $::prometheus::params::rule_files,
   $scrape_configs       = $::prometheus::params::scrape_configs,
-  $alerts               = $::prometheus::params::alerts
-
+  $alerts               = $::prometheus::params::alerts,
+  $alert_relabel_config = $::prometheus::params::alert_relabel_config,
+  $alertmanagers_config = $::prometheus::params::alertmanagers_config,
 ) inherits prometheus::params {
   if( versioncmp($::prometheus::version, '1.0.0') == -1 ){
     $real_download_url    = pick($download_url,
@@ -155,6 +162,8 @@ class prometheus (
   validate_hash($global_config)
   validate_array($rule_files)
   validate_array($scrape_configs)
+  validate_array($alert_relabel_config)
+  validate_array($alertmanagers_config)
 
   $config_hash_real = deep_merge($config_defaults, $config_hash)
   validate_hash($config_hash_real)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,8 @@
 # Class prometheus::params
 # Include default parameters for prometheus class
 class prometheus::params {
+  $alert_relabel_config = []
+  $alertmanagers_config = []
   $alertmanager_config_dir = '/etc/alertmanager'
   $alertmanager_config_file = "${alertmanager_config_dir}/alertmanager.yaml"
   $alertmanager_download_extension = 'tar.gz'

--- a/templates/prometheus.yaml.erb
+++ b/templates/prometheus.yaml.erb
@@ -2,5 +2,13 @@
 <% global_config = scope.lookupvar('::prometheus::global_config') -%>
 <% rule_files = scope.lookupvar('::prometheus::rule_files') -%>
 <% scrape_configs = scope.lookupvar('::prometheus::scrape_configs') -%>
-<% full_config = { 'global'=>global_config, 'rule_files'=>rule_files, 'scrape_configs'=>scrape_configs } -%>
+<% full_config = {
+  'global'=>global_config,
+  'rule_files'=>rule_files,
+  'scrape_configs'=>scrape_configs,
+  'alerting'=>{
+    'alert_relabel_configs'=>scope.lookupvar('::prometheus::alert_relabel_config'),
+    'alertmanagers'=>scope.lookupvar('::prometheus::alertmanagers_config'),
+  }
+} -%>
 <%= full_config.to_yaml -%>


### PR DESCRIPTION
More recent versions of puppet added the alerting configuration.

It allows you to dynamically discover alertmanagers from prometheus and relabel alerts before sending them to the alertmanagers.

This patch introduces these configuration topics.

Best regards,


   Steven
