### PR TITLE
Reload Prometheus service instead of restarting

### DIFF
--- a/manifests/run_service.pp
+++ b/manifests/run_service.pp
@@ -12,9 +12,11 @@ class prometheus::run_service {
 
   if $prometheus::manage_service == true {
     service { 'prometheus':
-      ensure => $prometheus::service_ensure,
-      name   => $init_selector,
-      enable => $prometheus::service_enable,
+      ensure     => $prometheus::service_ensure,
+      name       => $init_selector,
+      enable     => $prometheus::service_enable,
+      hasrestart => true,
+      restart    => '/usr/bin/pkill -HUP prometheus',
     }
   }
 }


### PR DESCRIPTION
Reloading the Prometheus service is sufficient for configuration or alert changes. Currently restarting the service is causing Prometheus to enter `crash-recovery` mode on a regular basis.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
