### PR TITLE
Puppet3 - StatsD Exporter Version/Release Change

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,9 @@
 #  [*os*]
 #  Operating system (linux is supported)
 #
+#  [*data_retention*]
+#  Data retention policy (storage.tsdb.retention argument)
+#
 #  [*download_url*]
 #  Complete URL corresponding to the Prometheus release, default to undef
 #
@@ -116,6 +119,7 @@ class prometheus (
   $version              = $::prometheus::params::version,
   $install_method       = $::prometheus::params::install_method,
   $os                   = $::prometheus::params::os,
+  $data_retention       = $::prometheus::params::data_retention,
   $download_url         = undef,
   $download_url_base    = $::prometheus::params::download_url_base,
   $download_extension   = $::prometheus::params::download_extension,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,7 @@ class prometheus::params {
   $config_dir = '/etc/prometheus'
   $config_mode = '0660'
   $config_template = 'prometheus/prometheus.yaml.erb'
+  $data_retention = '15d'
   $download_extension = 'tar.gz'
   $download_url_base = 'https://github.com/prometheus/prometheus/releases'
   $extra_groups = []

--- a/manifests/statsd_exporter.pp
+++ b/manifests/statsd_exporter.pp
@@ -106,6 +106,13 @@ class prometheus::statsd_exporter (
   $user                 = $::prometheus::params::statsd_exporter_user,
   $version              = $::prometheus::params::statsd_exporter_version,
 ) inherits prometheus::params {
+  # Prometheus added a 'v' on the realease name at 0.3.0
+  if versioncmp ($version, '0.3.0') >= 0 {
+    $release = "v${version}"
+  }
+  else {
+    $release = $version
+  }
   $real_download_url    = pick($download_url,"${download_url_base}/download/${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
   validate_bool($purge_config_dir)
   validate_bool($manage_user)

--- a/manifests/statsd_exporter.pp
+++ b/manifests/statsd_exporter.pp
@@ -106,14 +106,15 @@ class prometheus::statsd_exporter (
   $user                 = $::prometheus::params::statsd_exporter_user,
   $version              = $::prometheus::params::statsd_exporter_version,
 ) inherits prometheus::params {
-  # Prometheus added a 'v' on the realease name at 0.3.0
-  if versioncmp ($version, '0.3.0') >= 0 {
+  # Prometheus added a 'v' on the realease name at 0.4.0
+  if versioncmp ($version, '0.4.0') >= 0 {
     $release = "v${version}"
   }
   else {
     $release = $version
   }
-  $real_download_url    = pick($download_url,"${download_url_base}/download/${version}/${package_name}-${version}.${os}-${arch}.${download_extension}")
+  $real_download_url    = pick($download_url,"${download_url_base}/download/${release}/${package_name}-${version}.${os}-${arch}.${download_extension}")
+
   validate_bool($purge_config_dir)
   validate_bool($manage_user)
   validate_bool($manage_service)

--- a/templates/prometheus.systemd.erb
+++ b/templates/prometheus.systemd.erb
@@ -7,10 +7,10 @@ After=basic.target network.target
 User=<%= scope.lookupvar('prometheus::user') %>
 Group=<%= scope.lookupvar('prometheus::group') %>
 ExecStart=<%= scope.lookupvar('prometheus::bin_dir') %>/prometheus \
-  -config.file=<%= scope.lookupvar('prometheus::config_dir')+'/prometheus.yaml' %>\
-  -storage.local.path=<%= scope.lookupvar('prometheus::localstorage')%> \
-  -web.console.templates=<%= scope.lookupvar('prometheus::shared_dir') %>/consoles \
-  -web.console.libraries=<%= scope.lookupvar('prometheus::shared_dir') %>/console_libraries \
+  --config.file=<%= scope.lookupvar('prometheus::config_dir')+'/prometheus.yaml' %>\
+  --storage.tsdb.path=<%= scope.lookupvar('prometheus::localstorage')%> \
+  --web.console.templates=<%= scope.lookupvar('prometheus::shared_dir') %>/consoles \
+  --web.console.libraries=<%= scope.lookupvar('prometheus::shared_dir') %>/console_libraries \
   <%= scope.lookupvar('prometheus::extra_options') %>
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process

--- a/templates/prometheus.systemd.erb
+++ b/templates/prometheus.systemd.erb
@@ -9,6 +9,7 @@ Group=<%= scope.lookupvar('prometheus::group') %>
 ExecStart=<%= scope.lookupvar('prometheus::bin_dir') %>/prometheus \
   --config.file=<%= scope.lookupvar('prometheus::config_dir')+'/prometheus.yaml' %>\
   --storage.tsdb.path=<%= scope.lookupvar('prometheus::localstorage')%> \
+  --storage.tsdb.retention=<%= scope.lookupvar('prometheus::data_retention')%> \
   --web.console.templates=<%= scope.lookupvar('prometheus::shared_dir') %>/consoles \
   --web.console.libraries=<%= scope.lookupvar('prometheus::shared_dir') %>/console_libraries \
   <%= scope.lookupvar('prometheus::extra_options') %>


### PR DESCRIPTION
Same change as from the Node Exporter.  Prometheus added a `v` to the release nam in 0.4.0.
